### PR TITLE
Fix delegate property type

### DIFF
--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.h
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.h
@@ -57,7 +57,7 @@ typedef void (^MCSwipeCompletionBlock)(MCSwipeTableViewCell *cell, MCSwipeTableV
 @interface MCSwipeTableViewCell : UITableViewCell
 
 /** Delegate of `MCSwipeTableViewCell` */
-@property (nonatomic, assign) id <MCSwipeTableViewCellDelegate> delegate;
+@property (nonatomic, weak) id <MCSwipeTableViewCellDelegate> delegate;
 
 /** 
  * Damping of the physical spring animation. Expressed in percent.

--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.h
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.h
@@ -179,6 +179,11 @@ typedef void (^MCSwipeCompletionBlock)(MCSwipeTableViewCell *cell, MCSwipeTableV
  */
 - (void)triggerState1;
 
+/**
+ *  Trigger state 1 as if the user had swiped and released, and specify the animation duration
+ */
+- (void)triggerState1WithDuration:(NSTimeInterval)duration;
+
 @end
 
 

--- a/MCSwipeTableViewCell/MCSwipeTableViewCell.m
+++ b/MCSwipeTableViewCell/MCSwipeTableViewCell.m
@@ -645,7 +645,11 @@ typedef NS_ENUM(NSUInteger, MCSwipeTableViewCellDirection) {
 #pragma mark - Trigger Manually
 
 - (void)triggerState1 {
-    [UIView animateWithDuration:0.15f animations:^{
+    [self triggerState1WithDuration:0.15];
+}
+
+- (void)triggerState1WithDuration:(NSTimeInterval)duration {
+    [UIView animateWithDuration:duration animations:^{
         [self animateSliderWithXTranslation:-70.f animationDuration:0 hasEnded:NO];
     } completion:^(BOOL finished) {
         [self animateSliderWithXTranslation:0.f animationDuration:0 hasEnded:YES];


### PR DESCRIPTION
Should have `weak` property type as it will be set to nil automatically when the object is deallocated.